### PR TITLE
adding total number of isoforms to HTML

### DIFF
--- a/src/main/java/org/jax/isopret/visualization/EnsemblVisualizable.java
+++ b/src/main/java/org/jax/isopret/visualization/EnsemblVisualizable.java
@@ -63,6 +63,16 @@ public class EnsemblVisualizable implements Visualizable {
     }
 
     @Override
+    public int getTotalTranscriptCount() {
+        return this.totalTranscriptCount;
+    }
+
+    @Override
+    public int getExpressedTranscriptCount() {
+        return this.expressedTranscripts.size();
+    }
+
+    @Override
     public String getGeneUrl() {
         return getEnsemblUrl(getGeneAccession());
     }

--- a/src/main/java/org/jax/isopret/visualization/HtmlVisualizer.java
+++ b/src/main/java/org/jax/isopret/visualization/HtmlVisualizer.java
@@ -47,7 +47,7 @@ public class HtmlVisualizer implements Visualizer {
         return sb.toString();
     }
 
-    private final static String HTML_TABLE_HEADER = "<table>\n" +
+    private final static String ISOFORM_TABLE_HEADER = "<table>\n" +
             "  <thead>\n" +
             "    <tr>\n" +
             "      <th>Isoform</th>\n" +
@@ -63,7 +63,11 @@ public class HtmlVisualizer implements Visualizer {
         if (tableData.isEmpty()) {
             return "<p>No isoform data found.</p>\n";
         }
-        sb.append(HTML_TABLE_HEADER);
+        int totalIsoforms = vis.getTotalTranscriptCount();
+        int expressionIsoforms = vis.getExpressedTranscriptCount();
+        sb.append("<p>").append(expressionIsoforms).append(" transcripts were expressed in the data from ")
+                .append(totalIsoforms).append(" annotated transcripts.</p>\n");
+        sb.append(ISOFORM_TABLE_HEADER);
         for (var row : tableData) {
             if (row.size() != 4) {
                 // should never happen!

--- a/src/main/java/org/jax/isopret/visualization/Visualizable.java
+++ b/src/main/java/org/jax/isopret/visualization/Visualizable.java
@@ -13,6 +13,10 @@ public interface Visualizable {
 
     String getChromosome();
 
+    int getExpressedTranscriptCount();
+
+    int getTotalTranscriptCount();
+
     double getExpressionPval();
 
     double getExpressionFoldChange();


### PR DESCRIPTION
It might also be interesting to compare the expressed with the non-expressed isoforms, or perhaps to have an option to show all isoforms in the SVG but put the expressed ones in a special box. But let's leave that for a v2